### PR TITLE
Fix typo in build instruction

### DIFF
--- a/README.md
+++ b/README.md
@@ -67,5 +67,5 @@ cd ~/ros2_ws/src
 git clone https://github.com/koide3/glim_ext
 
 cd ..
-concon build
+colcon build
 ```


### PR DESCRIPTION
tiny typo in ros2 build instruction.

`concon` -> `colcon`