### PR TITLE
Fix building with --symlink-install option

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -14,6 +14,17 @@ option(ENABLE_DBOW "Enable DBoW Loop Detector" OFF)
 option(ENABLE_GNSS "Enable GNSS module (ROS2 is not supported)" ON)
 option(ENABLE_FLATEARTHER "Enable flat earth assumption module" ON)
 
+#################
+## ROS-related ##
+#################
+if(DEFINED ENV{ROS_VERSION})
+  if($ENV{ROS_VERSION} EQUAL 2)
+    find_package(ament_cmake REQUIRED)
+  elseif($ENV{ROS_VERSION} EQUAL 1)
+    # ROS1
+    find_package(catkin REQUIRED)
+  endif()
+endif()
 
 find_package(glim REQUIRED)
 
@@ -81,14 +92,11 @@ if(DEFINED ENV{ROS_VERSION})
   if($ENV{ROS_VERSION} EQUAL 2)
     # ROS2
     install(DIRECTORY config DESTINATION share/glim_ext)
-
-    find_package(ament_cmake REQUIRED)
     ament_target_dependencies(glim_ext glim)
     ament_export_libraries(${glim_ext_LIBRARIES})
     ament_package()
   elseif($ENV{ROS_VERSION} EQUAL 1)
     # ROS1
-    find_package(catkin REQUIRED)
     catkin_package(
       LIBRARIES ${glim_ext_LIBRARIES}
     )


### PR DESCRIPTION
Moving find_package to the top of the cmake file prevents a recursive loop during a build with --symlink-install.

See: https://github.com/ament/ament_cmake/issues/358 for more details