### PR TITLE
fix: segmentation fault error during SacnContext Loop closing 

### DIFF
--- a/modules/mapping/scan_context_loop_detector/src/glim_ext/scan_context_loop_detector.cpp
+++ b/modules/mapping/scan_context_loop_detector/src/glim_ext/scan_context_loop_detector.cpp
@@ -153,7 +153,7 @@ public:
         const double heading = std::get<2>(loop_candidate);
 
         // The frame is newer than the latest submap
-        if (frame_id1 > submaps.back()->odom_frames.back()->id) {
+        if (frame_id1 > submaps.back()->id) {
           break;
         }
         loop_candidates.pop_front();


### PR DESCRIPTION
Hello!

When enabling the Loop Closure feature using ScanContext, I encountered a segmentation fault during runtime, although the build was successful. I have debugged the issue and resolved the error. I am now submitting a pull request with the fix.

Thank you!